### PR TITLE
feat: Allow directories as sources

### DIFF
--- a/helm/helm-chart-package.bzl
+++ b/helm/helm-chart-package.bzl
@@ -69,7 +69,7 @@ def _helm_chart_impl(ctx):
                 outputs = [out],
                 inputs = [srcfile],
                 arguments = [srcfile.path, out.path],
-                command = "cp $1 $2",
+                command = "cp -r $1 $2",
             )
 
     if tmp_chart_root == "":
@@ -113,7 +113,7 @@ def _helm_chart_impl(ctx):
                 outputs = [out],
                 inputs = [file],
                 arguments = [file.path, out.path],
-                command = "cp $1 $2",
+                command = "cp -r $1 $2",
             )
 
     exec_file = ctx.actions.declare_file(ctx.label.name + "_helm_bash")


### PR DESCRIPTION
Internal shell copy commands don't recursively copy which breaks if a source DefaultInfo path is to a directory and not a file.